### PR TITLE
Updates to support reversed dutch auction

### DIFF
--- a/src/allocators/ERC7683Allocator.sol
+++ b/src/allocators/ERC7683Allocator.sol
@@ -117,20 +117,9 @@ contract ERC7683Allocator is SimpleAllocator, IERC7683Allocator {
     }
 
     /// @inheritdoc IERC7683Allocator
-    function completeOriginData(bytes memory originData_, address claimant_)
-        external
-        pure
-        returns (bytes memory originData)
-    {
-        (
-            Claim memory claim,
-            Mandate memory mandate, /* empty receiver of the tokens */
-            ,
-            uint256 targetBlock,
-            uint256 maximumBlocksAfterTarget
-        ) = abi.decode(originData_, (Claim, Mandate, address, uint256, uint256));
-        originData = abi.encode(claim, mandate, claimant_, targetBlock, maximumBlocksAfterTarget);
-        return originData;
+    function createFillerData(address claimant_) external pure returns (bytes memory fillerData) {
+        fillerData = abi.encode(claimant_);
+        return fillerData;
     }
 
     function _open(OrderData memory orderData_, uint32 fillDeadline_, address sponsor_, bytes memory sponsorSignature_)
@@ -258,7 +247,7 @@ contract ERC7683Allocator is SimpleAllocator, IERC7683Allocator {
         fillInstructions[0] = FillInstruction({
             destinationChainId: orderData.chainId,
             destinationSettler: _addressToBytes32(orderData.tribunal),
-            originData: abi.encode(claim, mandate, address(0), orderData.targetBlock, orderData.maximumBlocksAfterTarget)
+            originData: abi.encode(claim, mandate, orderData.targetBlock, orderData.maximumBlocksAfterTarget)
         });
 
         Output memory spent = Output({

--- a/src/allocators/ERC7683Allocator.sol
+++ b/src/allocators/ERC7683Allocator.sol
@@ -12,22 +12,22 @@ import {Compact} from '@uniswap/the-compact/types/EIP712Types.sol';
 contract ERC7683Allocator is SimpleAllocator, IERC7683Allocator {
     /// @notice The typehash of the OrderData struct
     //          keccak256("OrderData(address arbiter,address sponsor,uint256 nonce,uint256 id,uint256 amount,Mandate mandate)
-    //          Mandate(uint256 chainId,address tribunal,address recipient,uint256 expires,address token,uint256 minimumAmount,uint256 baselinePriorityFee,uint256 scalingFactor,bytes32 salt)")
-    bytes32 public constant ORDERDATA_TYPEHASH = 0x9e0e1bdb0df35509b65bbc49d209dd42496c5a3f13998f9a74dc842d6932656b;
+    //          Mandate(uint256 chainId,address tribunal,address recipient,uint256 expires,address token,uint256 minimumAmount,uint256 baselinePriorityFee,uint256 scalingFactor,uint256[] decayCurve,bytes32 salt)")
+    bytes32 public constant ORDERDATA_TYPEHASH = 0x524227237e80c55bea046dee5ee8323384274111dd94aadae8ce9bbc3916facb;
 
     /// @notice The typehash of the OrderDataGasless struct
     //          keccak256("OrderDataGasless(address arbiter,uint256 id,uint256 amount,Mandate mandate)
-    //          Mandate(uint256 chainId,address tribunal,address recipient,uint256 expires,address token,uint256 minimumAmount,uint256 baselinePriorityFee,uint256 scalingFactor,bytes32 salt)")
+    //          Mandate(uint256 chainId,address tribunal,address recipient,uint256 expires,address token,uint256 minimumAmount,uint256 baselinePriorityFee,uint256 scalingFactor,uint256[] decayCurve,bytes32 salt)")
     bytes32 public constant ORDERDATA_GASLESS_TYPEHASH =
-        0x9ab67658b7c0f35b64fdadd7adee1e58b6399a8201f38c355d3a109a2d7081d7;
+        0x3d6dd96d82595484a68f0b4dcd56a17557e8e675c9aa8e149d6166912a791704;
 
     /// @notice keccak256("Compact(address arbiter,address sponsor,uint256 nonce,uint256 expires,uint256 id,uint256 amount,Mandate mandate)
-    //          Mandate(uint256 chainId,address tribunal,address recipient,uint256 expires,address token,uint256 minimumAmount,uint256 baselinePriorityFee,uint256 scalingFactor,bytes32 salt)")
+    //          Mandate(uint256 chainId,address tribunal,address recipient,uint256 expires,address token,uint256 minimumAmount,uint256 baselinePriorityFee,uint256 scalingFactor,uint256[] decayCurve,bytes32 salt)")
     bytes32 public constant COMPACT_WITNESS_TYPEHASH =
-        0x27f09e0bb8ce2ae63380578af7af85055d3ada248c502e2378b85bc3d05ee0b0;
+        0xfd9cda0e5e31a3a3476cb5b57b07e2a4d6a12815506f69c880696448cd9897a5;
 
-    /// @notice keccak256("Mandate(uint256 chainId,address tribunal,address recipient,uint256 expires,address token,uint256 minimumAmount,uint256 baselinePriorityFee,uint256 scalingFactor,bytes32 salt)")
-    bytes32 internal constant MANDATE_TYPEHASH = 0x52c75464356e20084ae43acac75087fbf0e0c678e7ffa326f369f37e88696036;
+    /// @notice keccak256("Mandate(uint256 chainId,address tribunal,address recipient,uint256 expires,address token,uint256 minimumAmount,uint256 baselinePriorityFee,uint256 scalingFactor,uint256[] decayCurve,bytes32 salt)")
+    bytes32 internal constant MANDATE_TYPEHASH = 0x74d9c10530859952346f3e046aa2981a24bb7524b8394eb45a9deddced9d6501;
 
     /// @notice uint256(uint8(keccak256("ERC7683Allocator.nonce")))
     uint8 internal constant NONCE_MASTER_SLOT_SEED = 0x39;
@@ -101,7 +101,7 @@ contract ERC7683Allocator is SimpleAllocator, IERC7683Allocator {
     /// @inheritdoc IERC7683Allocator
     function getCompactWitnessTypeString() external pure returns (string memory) {
         return
-        'Compact(address arbiter,address sponsor,uint256 nonce,uint256 expires,uint256 id,uint256 amount,Mandate mandate)Mandate(uint256 chainId,address tribunal,address recipient,uint256 expires,address token,uint256 minimumAmount,uint256 baselinePriorityFee,uint256 scalingFactor,bytes32 salt))';
+        'Compact(address arbiter,address sponsor,uint256 nonce,uint256 expires,uint256 id,uint256 amount,Mandate mandate)Mandate(uint256 chainId,address tribunal,address recipient,uint256 expires,address token,uint256 minimumAmount,uint256 baselinePriorityFee,uint256 scalingFactor,uint256[] decayCurve,bytes32 salt))';
     }
 
     /// @inheritdoc IERC7683Allocator
@@ -151,6 +151,7 @@ contract ERC7683Allocator is SimpleAllocator, IERC7683Allocator {
                         orderData_.minimumAmount,
                         orderData_.baselinePriorityFee,
                         orderData_.scalingFactor,
+                        keccak256(abi.encodePacked(orderData_.decayCurve)),
                         orderData_.salt
                     )
                 )
@@ -220,6 +221,7 @@ contract ERC7683Allocator is SimpleAllocator, IERC7683Allocator {
             minimumAmount: orderData.minimumAmount,
             baselinePriorityFee: orderData.baselinePriorityFee,
             scalingFactor: orderData.scalingFactor,
+            decayCurve: orderData.decayCurve,
             salt: orderData.salt
         });
         Claim memory claim = Claim({
@@ -337,6 +339,7 @@ contract ERC7683Allocator is SimpleAllocator, IERC7683Allocator {
             minimumAmount: orderDataGasless_.minimumAmount,
             baselinePriorityFee: orderDataGasless_.baselinePriorityFee,
             scalingFactor: orderDataGasless_.scalingFactor,
+            decayCurve: orderDataGasless_.decayCurve,
             salt: orderDataGasless_.salt
         });
         return orderData_;

--- a/src/allocators/types/TribunalStructs.sol
+++ b/src/allocators/types/TribunalStructs.sol
@@ -12,13 +12,14 @@ struct Claim {
 }
 
 struct Mandate {
-    // uint256 chainId; // (implicit arg, included in EIP712 payload)
-    // address tribunal; // (implicit arg, included in EIP712 payload)
-    address recipient; // Recipient of settled tokens
-    uint256 expires; // Mandate expiration timestamp
-    address token; // Settlement token (address(0) for native)
-    uint256 minimumAmount; // Minimum settlement amount
-    uint256 baselinePriorityFee; // Base fee threshold where scaling kicks in
-    uint256 scalingFactor; // Fee scaling multiplier (1e18 baseline)
-    bytes32 salt; // Replay protection parameter
+    // uint256 chainId; // (implicit arg, included in EIP712 payload).
+    // address tribunal; // (implicit arg, included in EIP712 payload).
+    address recipient; // Recipient of filled tokens.
+    uint256 expires; // Mandate expiration timestamp.
+    address token; // Fill token (address(0) for native).
+    uint256 minimumAmount; // Minimum fill amount.
+    uint256 baselinePriorityFee; // Base fee threshold where scaling kicks in.
+    uint256 scalingFactor; // Fee scaling multiplier (1e18 baseline).
+    uint256[] decayCurve; // Block durations, fill increases, & claim decreases.
+    bytes32 salt; // Replay protection parameter.
 }

--- a/src/interfaces/IERC7683Allocator.sol
+++ b/src/interfaces/IERC7683Allocator.sol
@@ -22,6 +22,7 @@ interface IERC7683Allocator is IOriginSettler {
         uint256 minimumAmount; // Minimum settlement amount
         uint256 baselinePriorityFee; // Base fee threshold where scaling kicks in
         uint256 scalingFactor; // Fee scaling multiplier (1e18 baseline)
+        uint256[] decayCurve; // Block durations, fill increases, & claim decreases.
         bytes32 salt; // Replay protection parameter
     }
 
@@ -42,6 +43,7 @@ interface IERC7683Allocator is IOriginSettler {
         uint256 minimumAmount; // Minimum settlement amount
         uint256 baselinePriorityFee; // Base fee threshold where scaling kicks in
         uint256 scalingFactor; // Fee scaling multiplier (1e18 baseline)
+        uint256[] decayCurve; // Block durations, fill increases, & claim decreases.
         bytes32 salt; // Replay protection parameter
     }
 

--- a/src/interfaces/IERC7683Allocator.sol
+++ b/src/interfaces/IERC7683Allocator.sol
@@ -24,6 +24,9 @@ interface IERC7683Allocator is IOriginSettler {
         uint256 scalingFactor; // Fee scaling multiplier (1e18 baseline)
         uint256[] decayCurve; // Block durations, fill increases, & claim decreases.
         bytes32 salt; // Replay protection parameter
+        // ADDITIONAL INPUT
+        uint256 targetBlock; // The block number at the target chain on which the PGA is executed / the reverse dutch auction starts.
+        uint256 maximumBlocksAfterTarget; // Blocks after target block that are still fillable.
     }
 
     struct OrderDataGasless {
@@ -45,6 +48,9 @@ interface IERC7683Allocator is IOriginSettler {
         uint256 scalingFactor; // Fee scaling multiplier (1e18 baseline)
         uint256[] decayCurve; // Block durations, fill increases, & claim decreases.
         bytes32 salt; // Replay protection parameter
+        // ADDITIONAL INPUT
+        uint256 targetBlock; // The block number at the target chain on which the PGA is executed / the reverse dutch auction starts.
+        uint256 maximumBlocksAfterTarget; // Blocks after target block that are still fillable.
     }
 
     error InvalidOriginSettler(address originSettler, address expectedOriginSettler);
@@ -78,4 +84,12 @@ interface IERC7683Allocator is IOriginSettler {
     /// @notice Checks if a nonce is free to be used
     /// @dev The nonce is the most significant 96 bits. The least significant 160 bits must be the sponsor address
     function checkNonce(address sponsor_, uint256 nonce_) external view returns (bool nonceFree_);
+
+    /// @notice Completes the origin data by adding the filler as a claimant in the fillInstructions from the ResolvedCrossChainOrder
+    /// @param originData_ The origin data from the open event
+    /// @param claimant_ The address claiming the origin tokens after a successful fill (typically the address of the filler)
+    function completeOriginData(bytes memory originData_, address claimant_)
+        external
+        pure
+        returns (bytes memory completeOriginData);
 }

--- a/src/interfaces/IERC7683Allocator.sol
+++ b/src/interfaces/IERC7683Allocator.sol
@@ -48,9 +48,6 @@ interface IERC7683Allocator is IOriginSettler {
         uint256 scalingFactor; // Fee scaling multiplier (1e18 baseline)
         uint256[] decayCurve; // Block durations, fill increases, & claim decreases.
         bytes32 salt; // Replay protection parameter
-        // ADDITIONAL INPUT
-        uint256 targetBlock; // The block number at the target chain on which the PGA is executed / the reverse dutch auction starts.
-        uint256 maximumBlocksAfterTarget; // Blocks after target block that are still fillable.
     }
 
     error InvalidOriginSettler(address originSettler, address expectedOriginSettler);

--- a/src/interfaces/IERC7683Allocator.sol
+++ b/src/interfaces/IERC7683Allocator.sol
@@ -85,11 +85,7 @@ interface IERC7683Allocator is IOriginSettler {
     /// @dev The nonce is the most significant 96 bits. The least significant 160 bits must be the sponsor address
     function checkNonce(address sponsor_, uint256 nonce_) external view returns (bool nonceFree_);
 
-    /// @notice Completes the origin data by adding the filler as a claimant in the fillInstructions from the ResolvedCrossChainOrder
-    /// @param originData_ The origin data from the open event
+    /// @notice Creates the filler data for the open event to be used on the IDestinationSettler
     /// @param claimant_ The address claiming the origin tokens after a successful fill (typically the address of the filler)
-    function completeOriginData(bytes memory originData_, address claimant_)
-        external
-        pure
-        returns (bytes memory completeOriginData);
+    function createFillerData(address claimant_) external pure returns (bytes memory fillerData);
 }

--- a/test/ERC7683Allocator.t.sol
+++ b/test/ERC7683Allocator.t.sol
@@ -51,6 +51,8 @@ abstract contract MocksSetup is Test {
     uint256 defaultScalingFactor = 0;
     uint256[] defaultDecayCurve = new uint256[](0);
     bytes32 defaultSalt = bytes32(0);
+    uint256 defaultTargetBlock = 100;
+    uint256 defaultMaximumBlocksAfterTarget = 10;
 
     bytes32 ORDERDATA_GASLESS_TYPEHASH;
     bytes32 ORDERDATA_TYPEHASH;
@@ -249,7 +251,9 @@ abstract contract GaslessCrossChainOrderData is CompactData {
                     baselinePriorityFee: mandate_.baselinePriorityFee,
                     scalingFactor: mandate_.scalingFactor,
                     decayCurve: mandate_.decayCurve,
-                    salt: mandate_.salt
+                    salt: mandate_.salt,
+                    targetBlock: defaultTargetBlock,
+                    maximumBlocksAfterTarget: defaultMaximumBlocksAfterTarget
                 })
             )
         });
@@ -285,7 +289,9 @@ abstract contract GaslessCrossChainOrderData is CompactData {
                     baselinePriorityFee: mandate_.baselinePriorityFee,
                     scalingFactor: mandate_.scalingFactor,
                     decayCurve: mandate_.decayCurve,
-                    salt: mandate_.salt
+                    salt: mandate_.salt,
+                    targetBlock: defaultTargetBlock,
+                    maximumBlocksAfterTarget: defaultMaximumBlocksAfterTarget
                 })
             )
         });
@@ -331,7 +337,9 @@ abstract contract OnChainCrossChainOrderData is CompactData {
                     baselinePriorityFee: mandate_.baselinePriorityFee,
                     scalingFactor: mandate_.scalingFactor,
                     decayCurve: mandate_.decayCurve,
-                    salt: mandate_.salt
+                    salt: mandate_.salt,
+                    targetBlock: defaultTargetBlock,
+                    maximumBlocksAfterTarget: defaultMaximumBlocksAfterTarget
                 })
             )
         });
@@ -365,7 +373,9 @@ abstract contract OnChainCrossChainOrderData is CompactData {
                     baselinePriorityFee: mandate_.baselinePriorityFee,
                     scalingFactor: mandate_.scalingFactor,
                     decayCurve: mandate_.decayCurve,
-                    salt: mandate_.salt
+                    salt: mandate_.salt,
+                    targetBlock: defaultTargetBlock,
+                    maximumBlocksAfterTarget: defaultMaximumBlocksAfterTarget
                 })
             )
         });
@@ -523,7 +533,7 @@ contract ERC7683Allocator_openFor is GaslessCrossChainOrderData {
         fillInstructions[0] = IOriginSettler.FillInstruction({
             destinationChainId: defaultOutputChainId,
             destinationSettler: bytes32(uint256(uint160(tribunal))),
-            originData: abi.encode(claim, _getMandate())
+            originData: abi.encode(claim, _getMandate(), address(0), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
         });
 
         IOriginSettler.ResolvedCrossChainOrder memory resolvedCrossChainOrder = IOriginSettler.ResolvedCrossChainOrder({
@@ -578,7 +588,7 @@ contract ERC7683Allocator_openFor is GaslessCrossChainOrderData {
         fillInstructions[0] = IOriginSettler.FillInstruction({
             destinationChainId: defaultOutputChainId,
             destinationSettler: bytes32(uint256(uint160(tribunal))),
-            originData: abi.encode(claim, _getMandate())
+            originData: abi.encode(claim, _getMandate(), address(0), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
         });
 
         IOriginSettler.ResolvedCrossChainOrder memory resolvedCrossChainOrder = IOriginSettler.ResolvedCrossChainOrder({
@@ -739,7 +749,7 @@ contract ERC7683Allocator_open is OnChainCrossChainOrderData {
         fillInstructions[0] = IOriginSettler.FillInstruction({
             destinationChainId: defaultOutputChainId,
             destinationSettler: bytes32(uint256(uint160(tribunal))),
-            originData: abi.encode(claim, _getMandate())
+            originData: abi.encode(claim, _getMandate(), address(0), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
         });
 
         IOriginSettler.ResolvedCrossChainOrder memory resolvedCrossChainOrder = IOriginSettler.ResolvedCrossChainOrder({
@@ -904,7 +914,7 @@ contract ERC7683Allocator_resolveFor is GaslessCrossChainOrderData {
         fillInstructions[0] = IOriginSettler.FillInstruction({
             destinationChainId: defaultOutputChainId,
             destinationSettler: bytes32(uint256(uint160(tribunal))),
-            originData: abi.encode(claim, _getMandate())
+            originData: abi.encode(claim, _getMandate(), address(0), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
         });
 
         IOriginSettler.ResolvedCrossChainOrder memory resolvedCrossChainOrder = IOriginSettler.ResolvedCrossChainOrder({
@@ -970,7 +980,7 @@ contract ERC7683Allocator_resolve is OnChainCrossChainOrderData {
         fillInstructions[0] = IOriginSettler.FillInstruction({
             destinationChainId: defaultOutputChainId,
             destinationSettler: bytes32(uint256(uint160(tribunal))),
-            originData: abi.encode(claim, _getMandate())
+            originData: abi.encode(claim, _getMandate(), address(0), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
         });
 
         IOriginSettler.ResolvedCrossChainOrder memory resolvedCrossChainOrder = IOriginSettler.ResolvedCrossChainOrder({

--- a/test/ERC7683Allocator.t.sol
+++ b/test/ERC7683Allocator.t.sol
@@ -533,7 +533,7 @@ contract ERC7683Allocator_openFor is GaslessCrossChainOrderData {
         fillInstructions[0] = IOriginSettler.FillInstruction({
             destinationChainId: defaultOutputChainId,
             destinationSettler: bytes32(uint256(uint160(tribunal))),
-            originData: abi.encode(claim, _getMandate(), address(0), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
+            originData: abi.encode(claim, _getMandate(), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
         });
 
         IOriginSettler.ResolvedCrossChainOrder memory resolvedCrossChainOrder = IOriginSettler.ResolvedCrossChainOrder({
@@ -588,7 +588,7 @@ contract ERC7683Allocator_openFor is GaslessCrossChainOrderData {
         fillInstructions[0] = IOriginSettler.FillInstruction({
             destinationChainId: defaultOutputChainId,
             destinationSettler: bytes32(uint256(uint160(tribunal))),
-            originData: abi.encode(claim, _getMandate(), address(0), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
+            originData: abi.encode(claim, _getMandate(), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
         });
 
         IOriginSettler.ResolvedCrossChainOrder memory resolvedCrossChainOrder = IOriginSettler.ResolvedCrossChainOrder({
@@ -749,7 +749,7 @@ contract ERC7683Allocator_open is OnChainCrossChainOrderData {
         fillInstructions[0] = IOriginSettler.FillInstruction({
             destinationChainId: defaultOutputChainId,
             destinationSettler: bytes32(uint256(uint160(tribunal))),
-            originData: abi.encode(claim, _getMandate(), address(0), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
+            originData: abi.encode(claim, _getMandate(), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
         });
 
         IOriginSettler.ResolvedCrossChainOrder memory resolvedCrossChainOrder = IOriginSettler.ResolvedCrossChainOrder({
@@ -914,7 +914,7 @@ contract ERC7683Allocator_resolveFor is GaslessCrossChainOrderData {
         fillInstructions[0] = IOriginSettler.FillInstruction({
             destinationChainId: defaultOutputChainId,
             destinationSettler: bytes32(uint256(uint160(tribunal))),
-            originData: abi.encode(claim, _getMandate(), address(0), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
+            originData: abi.encode(claim, _getMandate(), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
         });
 
         IOriginSettler.ResolvedCrossChainOrder memory resolvedCrossChainOrder = IOriginSettler.ResolvedCrossChainOrder({
@@ -980,7 +980,7 @@ contract ERC7683Allocator_resolve is OnChainCrossChainOrderData {
         fillInstructions[0] = IOriginSettler.FillInstruction({
             destinationChainId: defaultOutputChainId,
             destinationSettler: bytes32(uint256(uint160(tribunal))),
-            originData: abi.encode(claim, _getMandate(), address(0), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
+            originData: abi.encode(claim, _getMandate(), defaultTargetBlock, defaultMaximumBlocksAfterTarget)
         });
 
         IOriginSettler.ResolvedCrossChainOrder memory resolvedCrossChainOrder = IOriginSettler.ResolvedCrossChainOrder({


### PR DESCRIPTION
# Pull Request

## Description

The changes enable support for the new version of the tribunal, which allows for a combination of PGA and a reversed dutch auction. 
The major changes are:
- Extending the Mandate to its current version in the tribunal, which includes a decayCurve allowing to tweak the reverse dutch auction
- Extending the inputs of the `open` function with a `targetBlock` and a `maximumBlocksAfterTarget` used in the tribunal.
- Both the `targetBlock` and the `maximumBlocksAfterTarget` input get used as qualification data. This means the allocator enhances the original claim hash with this data and only approves the ERC1271 isValid signature callback during the claim, if the correct qualificationPayload is provided by the arbiter, guaranteeing that these values were actually used to fill the order.
- Adding a `createFillerData` function which allows fillers to easily create the fillerData bytes that is needed in the IDestinationSettler ([The ERC7683 compatible version of the tribunal](https://github.com/Uniswap/Tribunal/blob/main/src/ERC7683Tribunal.sol)). Currently only converting the claimant address into a bytes, so more of a research resource currently then fulfilling an actual use case. Will become useful if more filler data is required at some point.