### PR TITLE
L-10: Validate originChainId in gasless order preparation

### DIFF
--- a/snapshots/ERC7683Allocator_openFor.json
+++ b/snapshots/ERC7683Allocator_openFor.json
@@ -1,3 +1,3 @@
 {
-  "openFor_simpleOrder_userHimself": "171750"
+  "openFor_simpleOrder_userHimself": "171785"
 }

--- a/src/allocators/lib/ERC7683AllocatorLib.sol
+++ b/src/allocators/lib/ERC7683AllocatorLib.sol
@@ -51,6 +51,7 @@ library ERC7683AllocatorLib {
     error InvalidRecipientCallbackLength();
     error InvalidOrderDataType(bytes32 orderDataType, bytes32 expectedOrderDataType);
     error InvalidOriginSettler(address originSettler, address expectedOriginSettler);
+    error InvalidOriginChainId(uint256 originChainId, uint256 expectedChainId);
     error InvalidOrderData(bytes orderData);
 
     /// @notice Checks and decodes the order data for a gasless cross-chain order.
@@ -77,6 +78,10 @@ library ERC7683AllocatorLib {
         // Check if the originSettler is the allocator
         if (order.originSettler != address(this)) {
             revert InvalidOriginSettler(order.originSettler, address(this));
+        }
+        // Check that the order is intended for the current chain
+        if (order.originChainId != block.chainid) {
+            revert InvalidOriginChainId(order.originChainId, block.chainid);
         }
 
         // Decode the orderData

--- a/test/ERC7683Allocator.t.sol
+++ b/test/ERC7683Allocator.t.sol
@@ -198,6 +198,16 @@ contract ERC7683Allocator_open is MockAllocator {
 }
 
 contract ERC7683Allocator_openFor is MockAllocator {
+    function test_revert_InvalidOriginChainId(uint256 wrongChainId) public {
+        vm.assume(wrongChainId != block.chainid);
+        IOriginSettler.GaslessCrossChainOrder memory gasless = _getGaslessCrossChainOrder();
+        gasless.originChainId = wrongChainId;
+        vm.prank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(ERC7683AL.InvalidOriginChainId.selector, wrongChainId, block.chainid)
+        );
+        erc7683Allocator.openFor(gasless, '', '');
+    }
     function test_revert_InvalidOrderDataType() public {
         // Order data type is invalid
         bytes32 falseOrderDataType = keccak256('false');


### PR DESCRIPTION
## Summary
- Adds `originChainId` validation in `ERC7683AllocatorLib.openForPreparation`
  - enforces `order.originChainId == block.chainid`.
- Introduces new error `InvalidOriginChainId(uint256, uint256)`.

### Changes
- `src/allocators/lib/ERC7683AllocatorLib.sol`: added `InvalidOriginChainId` error and validation in `openForPreparation`.
- `test/ERC7683Allocator.t.sol`: added negative test for invalid `originChainId`.

### Rationale
Ensures orders are processed only on the intended origin chain, preventing misuse across chains.