### PR TITLE
N-06: Early-revert on zero native value for first id in HybridAllocator

### DIFF
--- a/snapshots/HybridAllocatorTest.json
+++ b/snapshots/HybridAllocatorTest.json
@@ -1,10 +1,10 @@
 {
   "allocateAndRegister_erc20Token": "187668",
   "allocateAndRegister_erc20Token_emptyAmountInput": "188578",
-  "allocateAndRegister_multipleTokens": "223574",
-  "allocateAndRegister_nativeToken": "139204",
-  "allocateAndRegister_nativeToken_emptyAmountInput": "139040",
+  "allocateAndRegister_multipleTokens": "223592",
+  "allocateAndRegister_nativeToken": "139222",
+  "allocateAndRegister_nativeToken_emptyAmountInput": "139058",
   "allocateAndRegister_second_erc20Token": "114874",
-  "allocateAndRegister_second_nativeToken": "104840",
+  "allocateAndRegister_second_nativeToken": "104858",
   "hybrid_execute_single": "174395"
 }

--- a/src/allocators/HybridAllocator.sol
+++ b/src/allocators/HybridAllocator.sol
@@ -210,6 +210,10 @@ contract HybridAllocator is IHybridAllocator {
             if (AL.splitAllocatorId(idsAndAmounts[0][0]) != ALLOCATOR_ID) {
                 revert InvalidAllocatorId(AL.splitAllocatorId(idsAndAmounts[0][0]), ALLOCATOR_ID);
             }
+            // If first token is native and no value attached, revert early
+            if (msg.value == 0) {
+                revert InvalidValue(0, 1);
+            }
             if (idsAndAmounts[0][1] != 0 && msg.value != idsAndAmounts[0][1]) {
                 revert InvalidValue(msg.value, idsAndAmounts[0][1]);
             }

--- a/test/HybridAllocator.t.sol
+++ b/test/HybridAllocator.t.sol
@@ -275,7 +275,7 @@ contract HybridAllocatorTest is Test, TestHelper {
         uint256[2][] memory idsAndAmounts = new uint256[2][](1);
         idsAndAmounts[0][0] = _toId(Scope.Multichain, ResetPeriod.TenMinutes, address(allocator), address(0));
         idsAndAmounts[0][1] = 0;
-        vm.expectRevert(abi.encodeWithSelector(ITheCompact.InvalidBatchDepositStructure.selector));
+        vm.expectRevert(abi.encodeWithSelector(IHybridAllocator.InvalidValue.selector, 0, 1));
         allocator.allocateAndRegister(user, idsAndAmounts, arbiter, defaultExpiration, BATCH_COMPACT_TYPEHASH, '');
     }
 


### PR DESCRIPTION
In `HybridAllocator._actualIdsAndAmounts`, if first id is native and `msg.value == 0`, revert with `InvalidValue(0, 1)`. This early failure in allocator, rather than letting The Compact revert, provides a clearer error surface.

Test updated: `test_allocateAndRegister_revert_zeroNativeTokensAmount` now expects allocator-level revert.