### PR TITLE
N-11/N-12: Remove unused items and imports

### DIFF
--- a/src/allocators/ERC7683Allocator.sol
+++ b/src/allocators/ERC7683Allocator.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.27;
 import {IOriginSettler} from '../interfaces/ERC7683/IOriginSettler.sol';
 import {IERC7683Allocator} from '../interfaces/IERC7683Allocator.sol';
 import {OnChainAllocator} from './OnChainAllocator.sol';
-import {AllocatorLib as AL} from './lib/AllocatorLib.sol';
 import {ERC7683AllocatorLib as ERC7683AL} from './lib/ERC7683AllocatorLib.sol';
 
 import {Tribunal} from '@uniswap/tribunal/Tribunal.sol';

--- a/src/allocators/HybridERC7683.sol
+++ b/src/allocators/HybridERC7683.sol
@@ -4,19 +4,8 @@ pragma solidity ^0.8.27;
 
 import {ERC7683AllocatorLib as ERC7683AL} from './lib/ERC7683AllocatorLib.sol';
 import {LibBytes} from '@solady/utils/LibBytes.sol';
-import {IAllocator} from '@uniswap/the-compact/interfaces/IAllocator.sol';
-import {BatchCompact, Lock} from '@uniswap/the-compact/types/EIP712Types.sol';
-import {Tribunal} from '@uniswap/tribunal/Tribunal.sol';
-import {Fill, Mandate} from '@uniswap/tribunal/types/TribunalStructs.sol';
 
-import {
-    COMPACT_TYPEHASH_WITH_MANDATE,
-    COMPACT_WITH_MANDATE_TYPESTRING,
-    MANDATE_BATCH_COMPACT_TYPEHASH,
-    MANDATE_FILL_TYPEHASH,
-    MANDATE_RECIPIENT_CALLBACK_TYPEHASH,
-    MANDATE_TYPEHASH
-} from '@uniswap/tribunal/types/TribunalTypeHashes.sol';
+import {COMPACT_TYPEHASH_WITH_MANDATE, COMPACT_WITH_MANDATE_TYPESTRING} from '@uniswap/tribunal/types/TribunalTypeHashes.sol';
 import {HybridAllocator} from 'src/allocators/HybridAllocator.sol';
 import {IERC7683Allocator} from 'src/interfaces/IERC7683Allocator.sol';
 


### PR DESCRIPTION
## Summary
Audited unused variables; removed unused imports:
- Dropped `AllocatorLib as AL` from `ERC7683Allocator.sol` (unused).
- Trimmed unused imports in `HybridERC7683`; kept only needed `COMPACT_TYPEHASH_WITH_MANDATE` and `COMPACT_WITH_MANDATE_TYPESTRING`.