### PR TITLE
N-04: Two-step signer replacement to prevent bricking

### DIFF
--- a/snapshots/HybridAllocatorTest.json
+++ b/snapshots/HybridAllocatorTest.json
@@ -1,10 +1,10 @@
 {
-  "allocateAndRegister_erc20Token": "187668",
-  "allocateAndRegister_erc20Token_emptyAmountInput": "188578",
-  "allocateAndRegister_multipleTokens": "223574",
-  "allocateAndRegister_nativeToken": "139204",
-  "allocateAndRegister_nativeToken_emptyAmountInput": "139040",
-  "allocateAndRegister_second_erc20Token": "114874",
-  "allocateAndRegister_second_nativeToken": "104840",
-  "hybrid_execute_single": "174395"
+  "allocateAndRegister_erc20Token": "187690",
+  "allocateAndRegister_erc20Token_emptyAmountInput": "188600",
+  "allocateAndRegister_multipleTokens": "223596",
+  "allocateAndRegister_nativeToken": "139226",
+  "allocateAndRegister_nativeToken_emptyAmountInput": "139062",
+  "allocateAndRegister_second_erc20Token": "114896",
+  "allocateAndRegister_second_nativeToken": "104862",
+  "hybrid_execute_single": "174439"
 }

--- a/snapshots/HybridAllocatorTest.json
+++ b/snapshots/HybridAllocatorTest.json
@@ -1,10 +1,10 @@
 {
-  "allocateAndRegister_erc20Token": "187690",
-  "allocateAndRegister_erc20Token_emptyAmountInput": "188600",
-  "allocateAndRegister_multipleTokens": "223596",
-  "allocateAndRegister_nativeToken": "139226",
-  "allocateAndRegister_nativeToken_emptyAmountInput": "139062",
-  "allocateAndRegister_second_erc20Token": "114896",
-  "allocateAndRegister_second_nativeToken": "104862",
-  "hybrid_execute_single": "174439"
+  "allocateAndRegister_erc20Token": "187701",
+  "allocateAndRegister_erc20Token_emptyAmountInput": "188611",
+  "allocateAndRegister_multipleTokens": "223607",
+  "allocateAndRegister_nativeToken": "139234",
+  "allocateAndRegister_nativeToken_emptyAmountInput": "139070",
+  "allocateAndRegister_second_erc20Token": "114907",
+  "allocateAndRegister_second_nativeToken": "104870",
+  "hybrid_execute_single": "174440"
 }

--- a/src/allocators/HybridAllocator.sol
+++ b/src/allocators/HybridAllocator.sol
@@ -13,6 +13,8 @@ import {ITheCompact} from '@uniswap/the-compact/interfaces/ITheCompact.sol';
 import {IHybridAllocator} from 'src/interfaces/IHybridAllocator.sol';
 
 contract HybridAllocator is IHybridAllocator {
+    event SignerReplacementProposed(address oldSigner, address newSigner);
+    event SignerReplaced(address oldSigner, address newSigner);
     uint96 public immutable ALLOCATOR_ID;
     ITheCompact internal immutable _COMPACT;
     bytes32 internal immutable _COMPACT_DOMAIN_SEPARATOR;
@@ -68,6 +70,7 @@ contract HybridAllocator is IHybridAllocator {
             revert InvalidSigner();
         }
         pendingSignerReplacement[msg.sender] = newSigner_;
+        emit SignerReplacementProposed(msg.sender, newSigner_);
     }
 
     function acceptSignerReplacement(address oldSigner_) external {
@@ -81,6 +84,7 @@ contract HybridAllocator is IHybridAllocator {
         delete pendingSignerReplacement[oldSigner_];
         signers[oldSigner_] = false;
         signers[newSigner_] = true;
+        emit SignerReplaced(oldSigner_, newSigner_);
     }
 
     /// @inheritdoc IAllocator

--- a/src/allocators/HybridAllocator.sol
+++ b/src/allocators/HybridAllocator.sol
@@ -23,6 +23,7 @@ contract HybridAllocator is IHybridAllocator {
     uint96 public nonces;
     uint256 public signerCount;
     mapping(address => bool) public signers;
+    mapping(address => address) public pendingSignerReplacement;
 
     modifier onlySigner() {
         if (!signers[msg.sender]) {
@@ -66,7 +67,19 @@ contract HybridAllocator is IHybridAllocator {
         if (newSigner_ == address(0) || signers[newSigner_]) {
             revert InvalidSigner();
         }
-        signers[msg.sender] = false;
+        pendingSignerReplacement[msg.sender] = newSigner_;
+    }
+
+    function acceptSignerReplacement(address oldSigner_) external {
+        address newSigner_ = pendingSignerReplacement[oldSigner_];
+        if (newSigner_ == address(0) || msg.sender != newSigner_) {
+            revert InvalidSigner();
+        }
+        if (!signers[oldSigner_]) {
+            revert InvalidSigner();
+        }
+        delete pendingSignerReplacement[oldSigner_];
+        signers[oldSigner_] = false;
         signers[newSigner_] = true;
     }
 

--- a/src/allocators/HybridAllocator.sol
+++ b/src/allocators/HybridAllocator.sol
@@ -60,6 +60,8 @@ contract HybridAllocator is IHybridAllocator {
         if (signerCount == 1 || !signers[signer_]) {
             revert LastSigner();
         }
+        // Clear any pending replacement proposed by this signer
+        delete pendingSignerReplacement[signer_];
         signers[signer_] = false;
         signerCount--;
     }

--- a/test/HybridAllocator.t.sol
+++ b/test/HybridAllocator.t.sol
@@ -1038,13 +1038,19 @@ contract HybridAllocatorTest is Test, TestHelper {
         assertFalse(allocator.signers(address(0)));
     }
 
-    function test_replaceSigner_success(address newSigner) public {
+    function test_replaceSigner_success_twoStep(address newSigner) public {
         vm.assume(newSigner != signer);
         vm.assume(newSigner != address(0));
         vm.prank(signer);
         allocator.replaceSigner(newSigner);
-        assertEq(allocator.signerCount(), 1);
+        // Not active until accepted by new signer
+        assertTrue(allocator.signers(signer));
+        assertFalse(allocator.signers(newSigner));
+
+        vm.prank(newSigner);
+        allocator.acceptSignerReplacement(signer);
         assertFalse(allocator.signers(signer));
         assertTrue(allocator.signers(newSigner));
+        assertEq(allocator.signerCount(), 1);
     }
 }


### PR DESCRIPTION
Introduces a confirmation step by the new signer to avoid accidental lockout. No interface breaking changes; only adds one public view mapping and a new external function.