### PR TITLE
N-15: remove duplicate import

### DIFF
--- a/src/allocators/lib/ERC7683AllocatorLib.sol
+++ b/src/allocators/lib/ERC7683AllocatorLib.sol
@@ -19,7 +19,6 @@ import {
 
 import {IOriginSettler} from 'src/interfaces/ERC7683/IOriginSettler.sol';
 
-import {IOriginSettler} from 'src/interfaces/ERC7683/IOriginSettler.sol';
 import {IERC7683Allocator} from 'src/interfaces/IERC7683Allocator.sol';
 
 /// @title ERC7683AllocatorLib


### PR DESCRIPTION
## Summary
Removed duplicate `IOriginSettler` import in ERC7683AllocatorLib